### PR TITLE
Using multiple-calls array on call() should return from callMultiple...

### DIFF
--- a/sdk/php/JSONAPI.php
+++ b/sdk/php/JSONAPI.php
@@ -82,7 +82,7 @@ class JSONAPI {
 	 */
 	public function call($method, array $args = array()) {
 		if(is_array($method)) {
-			$this->callMultiple($method, $args);
+			return $this->callMultiple($method, $args);
 		}
 		
 		$url = $this->makeURL($method, $args);


### PR DESCRIPTION
Using multiple-calls array on call() should return from callMultiple function, and not just call it.
