### PR TITLE
Suggest using source in maven-compiler-plugin so builders understand what

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,17 @@
 			</resource>
 		</resources>		
 	</build>
+	<plugins>
+		<plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+        </plugins>
 	<dependencies>
 		<dependency>
 			<groupId>org.bukkit</groupId>


### PR DESCRIPTION
Suggest using source in maven-compiler-plugin so builders understand what version they should compile against.
