### PR TITLE
Enable maven to build without known jdk.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
                     			<target>1.6</target>
                 		</configuration>
             		</plugin>
-		</plugin>
+		</plugins>
 	</build>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Tells the maven builder (mvn clean package) to use java version 1.6 when compiling, useful for automatic building for integration in jenkins/bamboo or other continuous integration software.
