### PR TITLE
Unix Timestamp fix

### DIFF
--- a/src/com/alecgorge/minecraft/jsonapi/api/JSONAPIStreamMessage.java
+++ b/src/com/alecgorge/minecraft/jsonapi/api/JSONAPIStreamMessage.java
@@ -43,7 +43,6 @@ abstract public class JSONAPIStreamMessage implements JSONAware {
 	 */
 	public void setTime() {
 		Calendar cal = Calendar.getInstance();
-		cal.add(Calendar.MILLISECOND, -cal.get(Calendar.DST_OFFSET) - cal.get(Calendar.ZONE_OFFSET));
 		long lUTCtime = cal.getTimeInMillis();
 
 		time = lUTCtime/1000;


### PR DESCRIPTION
Unix timestamps, aka POSIX time, is always the number of seconds which have lapsed since 1970/01/01 in UTC. The timezone adjustment and DST adjustment should be done at client end when rendering the time to show end-user, not on the server end.  Having this information modified here means the client must know where the server is located and makes further adjustments in order to render correctly.

This fixes Issue #179
