### PR TITLE
Make RemoteToolKit optional

### DIFF
--- a/src/com/alecgorge/minecraft/jsonapi/JSONAPI.java
+++ b/src/com/alecgorge/minecraft/jsonapi/JSONAPI.java
@@ -175,6 +175,8 @@ public class JSONAPI extends JavaPlugin implements JSONAPIMethodProvider {
 	File yamlFile;
 
 	public void onEnable() {
+		boolean rtkInstalled = Bukkit.getPluginManager().getPlugin("RemoteToolkitPlugin") != null;
+		
 		try {
 			auth = new HashMap<String, String>();
 
@@ -245,7 +247,7 @@ public class JSONAPI extends JavaPlugin implements JSONAPIMethodProvider {
 
 				log.info("[JSONAPI] config.yml has been copied from the jar");
 			}
-			if (!rtkConfig.exists()) {
+			if (rtkInstalled && !rtkConfig.exists()) {
 				rtkConfig.createNewFile();
 
 				InputStream in = getResource("config_rtk.yml");
@@ -322,17 +324,19 @@ public class JSONAPI extends JavaPlugin implements JSONAPIMethodProvider {
 					auth.put(k, yamlConfig.getString("logins." + k));
 				}
 			}
-
-			YamlConfiguration yamlRTK = new YamlConfiguration();
-
-			try {
-				yamlRTK.load(rtkConfig);
-				
-				Properties rtkProps = new Properties();
-				rtkProps.load(new FileInputStream("toolkit/remote.properties"));
-				
-			} catch (Exception e) {
-				e.printStackTrace();
+			
+			if (rtkInstalled) {
+				YamlConfiguration yamlRTK = new YamlConfiguration();
+	
+				try {
+					yamlRTK.load(rtkConfig);
+					
+					Properties rtkProps = new Properties();
+					rtkProps.load(new FileInputStream("toolkit/remote.properties"));
+					
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
 			}
 
 			if (!logging) {


### PR DESCRIPTION
Currently JSONAPI always creates a `config_rtk.yml` by default, no matter if RTK is even installed or not. It then requires the file `toolkit/remote.properties`, which of course isn't there and throws.

JSONAPI now only creates and checks for a `config_rtk.yml` and `toolkit/remote.properties` if RTK is installed.
I don't know, which stuff to put in `remote.properties` so I didn't wrote an auto creation wizard for it.
