### PR TITLE
Add __call function - PHP SDK

### DIFF
--- a/sdk/php/JSONAPI.php
+++ b/sdk/php/JSONAPI.php
@@ -126,9 +126,9 @@ class JSONAPI {
 	 */
 	function __call($method, $params) {
 		if(is_array($params)){
-			return call($method, $params);
+			return $this->call($method, $params);
 		}else{
-			return call($method, array($params));	
+			return $this->call($method, array($params));	
 		}
 	}
 }

--- a/sdk/php/JSONAPI.php
+++ b/sdk/php/JSONAPI.php
@@ -125,10 +125,10 @@ class JSONAPI {
 	 * @return array An associative array representing the JSON that was returned.
 	 */
 	function __call($method, $params) {
-		if(is_array($params)){
-			return $this->call($method, $params);
-		}else{
-			return $this->call($method, array($params));	
-		}
+                if(is_array($params)) {
+                    return $this->call($method, $params);
+                } else {
+                    return $this->call($method, array($params));	
+                }
 	}
 }

--- a/sdk/php/JSONAPI.php
+++ b/sdk/php/JSONAPI.php
@@ -117,4 +117,18 @@ class JSONAPI {
 
 		return json_decode($this->curl($url), true);
 	}
+	/**
+	 * The default function called if no one matched for JSONAPI.
+	 * 
+	 * @param string $method The name of the JSONAPI API method to call.
+	 * @param array $params An array of arguments that are to be passed.
+	 * @return array An associative array representing the JSON that was returned.
+	 */
+	function __call($method, $params) {
+		if(is_array($params)){
+			return call($method, $params);
+		}else{
+			return call($method, array($params));	
+		}
+	}
 }


### PR DESCRIPTION
This __call function allows JSONAPI to have a variable such as $api that works with JSONAPI's functions directly as if they were PHP functions.
How ?

For exemple, you had it :
$api->call('runConsoleCommand', array("broadcast MESSAGE")); 

Now, you just have : $api->runConsoleCommand('broadcast MESSAGE');

Isn't that cool ? :)
No ? ... :( 

Pull request anyway !
(untested, but could work ... Maybe ... ;D )
