### PR TITLE
Make SURE port passed is an integer

### DIFF
--- a/sdk/py/MinecraftApi.py
+++ b/sdk/py/MinecraftApi.py
@@ -214,7 +214,7 @@ class MinecraftJsonApi (object):
 		self.host = host
 		self.username = username
 		self.password = password
-		self.port = port
+		self.port = int(port)
 		self.salt = salt
 		self.__methods = []
 				


### PR DESCRIPTION
If port is a string MinecraftJsonApi.subscride throws an error, now it wont.
