### PR TITLE
#PHP Make cURL optional

### DIFF
--- a/sdk/php/JSONAPI.php
+++ b/sdk/php/JSONAPI.php
@@ -26,7 +26,7 @@ class JSONAPI {
 	/**
 	 * Creates a new JSONAPI instance.
 	 */
-	public function __construct ($host, $port, $uname, $pword, $salt, $timeout = 10) {
+	public function __construct ($host, $port, $uname, $pword, $salt = '', $timeout = 10) {
 		$this->host = $host;
 		$this->port = $port;
 		$this->username = $uname;


### PR DESCRIPTION
- Remove the requirement for cURL
- Add optional parameter to __construct, $timeout
- Only use single quote, not double (micro-optimization)
