### PR TITLE
Update README so that it includes a correct generation of keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ Here is a sample function to calculate a JSONAPI key in `PHP`:
 
 ```
 function generate_jsonapi_key($username, $password, $api_method_or_stream_name) {
-	return hash('sha256', $username . $password. $api_method_or_stream_name);
+	return hash('sha256', $username . $api_method_or_stream_name . $password);
 }
 ```
 


### PR DESCRIPTION
The PHP example for key generation wasn't correct. It concatenated password and method in the wrong order. This is fixed in this pull request.
