### PR TITLE
Use normalized name for World.Environment

### DIFF
--- a/src/main/java/com/alecgorge/minecraft/jsonapi/stringifier/BukkitStringifier.java
+++ b/src/main/java/com/alecgorge/minecraft/jsonapi/stringifier/BukkitStringifier.java
@@ -92,11 +92,7 @@ public class BukkitStringifier {
 	public static Object handle(Object obj) {
 		if (obj instanceof World.Environment) {
 			World.Environment e = (World.Environment) obj;
-			if (e == World.Environment.NETHER) {
-				return "nether";
-			} else {
-				return "normal";
-			}
+			return e.name().toLowerCase();
 		} else if (obj instanceof File) {
 			return ((File) obj).toString();
 		} else if (obj instanceof Block) {


### PR DESCRIPTION
This is so that JSONAPI is not dependent on the World.Environment.NETHER.

This works even when more world types are added and also adds THE_END, which had not been added previously
