### PR TITLE
Allow POST as HTTP method on port 25565

### DIFF
--- a/src/main/java/com/alecgorge/minecraft/jsonapi/packets/netty/APIv2Handler.java
+++ b/src/main/java/com/alecgorge/minecraft/jsonapi/packets/netty/APIv2Handler.java
@@ -4,6 +4,7 @@ package com.alecgorge.minecraft.jsonapi.packets.netty;
 //#else
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
@@ -150,9 +151,18 @@ public class APIv2Handler {
 	}
 	
 	public void readPayload(boolean stream) throws ParseException {
-		JSONAPI.dbug("params.json: "+uri.parameters().get("json").get(0));
-		if(uri.parameters().containsKey("json")) {
-			Object o = parser.parse(uri.parameters().get("json").get(0));
+        String json = null;
+        if (uri.parameters().containsKey("json")) {
+            json = uri.parameters().get("json").get(0);
+        } else {
+            ByteBuf byteBuf = request.content();
+            if (byteBuf.isReadable()) {
+                json = byteBuf.toString(Charset.forName("UTF-8"));
+            }
+        }
+
+        if (json != null) {
+            Object o = parser.parse(json);
 			
 			JSONAPI.dbug("json obj: "+ o);
 			

--- a/src/main/java/com/alecgorge/minecraft/jsonapi/packets/netty/router/JSONAPIDefaultRoutes.java
+++ b/src/main/java/com/alecgorge/minecraft/jsonapi/packets/netty/router/JSONAPIDefaultRoutes.java
@@ -39,32 +39,30 @@ public class JSONAPIDefaultRoutes {
 				return null;
 			}
 		});
-		
-		r.get("/api/2/call", new Handler<FullHttpResponse, RoutedHttpRequest>() {
-			@Override
-			public FullHttpResponse handle(RoutedHttpRequest event) {
-				APIv2Handler h = new APIv2Handler(event.request);
 
-				return h.serve();
-			}
-		});
+        Handler<FullHttpResponse, RoutedHttpRequest> apiHandler = new Handler<FullHttpResponse, RoutedHttpRequest>() {
+            @Override
+            public FullHttpResponse handle(RoutedHttpRequest event) {
+                APIv2Handler h = new APIv2Handler(event.request);
+                api.outLog.info("Request was matched");
 
-		r.get("/api/2/version", new Handler<FullHttpResponse, RoutedHttpRequest>() {
-			@Override
-			public FullHttpResponse handle(RoutedHttpRequest event) {
-				APIv2Handler h = new APIv2Handler(event.request);
+                return h.serve();
+            }
+        };
 
-				return h.serve();
-			}
-		});
+        r.get("/api/2/call", apiHandler);
+        r.post("/api/2/call", apiHandler);
 
-		r.get("/", new Handler<FullHttpResponse, RoutedHttpRequest>() {
-			@Override
-			public FullHttpResponse handle(RoutedHttpRequest event) {
-				return buildResponse(HttpResponseStatus.OK, "text/plain", "This is a Minecraft server. HTTP on this port by JSONAPI. JSONAPI by Alec Gorge.\n");
-			}
-		});
-	}
+        r.get("/api/2/version", apiHandler);
+        r.post("/api/2/version", apiHandler);
+
+        r.get("/", new Handler<FullHttpResponse, RoutedHttpRequest>() {
+            @Override
+            public FullHttpResponse handle(RoutedHttpRequest event) {
+                return buildResponse(HttpResponseStatus.OK, "text/plain", "This is a Minecraft server. HTTP on this port by JSONAPI. JSONAPI by Alec Gorge.\n");
+            }
+        });
+    }
 	
 	public static FullHttpResponse buildResponse(HttpResponseStatus resp, String type, String body) {
 		ByteBuf buf = Unpooled.copiedBuffer(body, CharsetUtil.UTF_8);


### PR DESCRIPTION
Up until now, it was not possible to do a POST on the Minecraft port, which I fixed by parsing the JSON from the  POST contents instead of parsing the json parameter in the query string.
