### PR TITLE
Fix URLs so they show the correct information again

### DIFF
--- a/src/main/java/com/alecgorge/minecraft/jsonapi/JSONServer.java
+++ b/src/main/java/com/alecgorge/minecraft/jsonapi/JSONServer.java
@@ -117,12 +117,12 @@ public class JSONServer extends NanoHTTPD {
 		outLog.info("[JSONAPI] Active and listening for requests.");
 
 		try {
-			URL whatismyip = new URL("http://tools.alecgorge.com/ip.php");
+			URL whatismyip = new URL("https://tools.alecgorge.com/ip.php");
             BufferedReader in = new BufferedReader(new InputStreamReader(whatismyip.openStream()));
 
             String ip = in.readLine();
             
-            URL checkURL = new URL("http://tools.alecgorge.com/port_check.php");
+            URL checkURL = new URL("https://tools.alecgorge.com/port_check.php");
             
             outLog.info("[JSONAPI] External IP: " + ip);
 


### PR DESCRIPTION
When you created a redirect from the normal http to the https version of tools.alecgorge.com, the Java script broke because it doesn't recognize redirects. This fixes it so that it will show the correct external IP instead of `[JSONAPI] External IP: <html>`.
