### PR TITLE
Update Vault repository URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,10 +42,10 @@
 			<id>spigot-repo</id>
 			<url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
 		</repository>
-		<repository>
-			<id>vault-repo</id>
-			<url>http://nexus.theyeticave.net/content/repositories/pub_releases</url>
-		</repository>
+                <repository>
+                        <id>vault-repo</id>
+                        <url>http://nexus.hc.to/content/repositories/pub_releases</url>
+                </repository>
 		<repository>
 			<id>dmulloy2-repo</id>
 			<url>http://repo.dmulloy2.net/content/groups/public/</url>


### PR DESCRIPTION
See this [commit](https://github.com/MilkBowl/VaultAPI/commit/6eaffac1858849789c566378baa6ee8a18a7c88a#diff-04c6e90faac2675aa89e2176d2eec7d8) on [VaultAPI](https://github.com/MilkBowl/VaultAPI) repository.

Fixes building
